### PR TITLE
set version after inheriting

### DIFF
--- a/plugins/CommonPlugin.php
+++ b/plugins/CommonPlugin.php
@@ -54,10 +54,10 @@ class CommonPlugin extends phplistPlugin
     public function __construct()
     {
         $this->coderoot = dirname(__FILE__) . '/CommonPlugin/';
+        parent::__construct();
         $this->version = (is_file($f = $this->coderoot . self::VERSION_FILE))
             ? file_get_contents($f)
             : '';
-        parent::__construct();
         include_once $this->coderoot . 'functions.php';
     }
 


### PR DESCRIPTION
I could not activate the RSS plugin, because it reported the dependency failing. It needed CommonPlugin v3 or up and my system reported CommonPlugin v Git - [date]

That version (Git - [date]) is set in the default plugin. By swapping these lines, the version reported is correct and the dependency passes.

Alternatively the version of the plugin should be set with the getVersion() method